### PR TITLE
Add text stroke to header and footer

### DIFF
--- a/docs/styles.css
+++ b/docs/styles.css
@@ -104,6 +104,9 @@ body {
   margin: 0;
   font-size: 1rem;
   font-weight: 400;
+  -webkit-text-stroke: 1px var(--color-bg);
+  /* stylelint-disable-next-line property-no-unknown */
+  text-stroke: 1px var(--color-bg);
 }
 
 .header__list {
@@ -157,6 +160,9 @@ body {
   color: currentColor;
   text-decoration: none;
   font-size: 0.875rem;
+  -webkit-text-stroke: 1px var(--color-bg);
+  /* stylelint-disable-next-line property-no-unknown */
+  text-stroke: 1px var(--color-bg);
 
   &:hover {
     text-decoration: underline;


### PR DESCRIPTION
## Summary
- add CSS stroke color set to the background for header and footer text

## Testing
- `npm run format`
- `npm run lint:css`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_b_687e828c47d08331b1e8b6178fd6a46a