### PR TITLE
Fix dialog focus state by focusing body instead of close button

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -148,7 +148,7 @@
               </svg>
             </button>
           </header>
-          <div class="dialog__body">
+          <div class="dialog__body" tabindex="-1">
             <p class="dialog__paragraph">
               I’m a front-end developer based in Gothenburg, Sweden, passionate about building scalable and accessible
               design systems that empower teams to deliver consistent, inclusive user experiences.

--- a/docs/script.js
+++ b/docs/script.js
@@ -423,12 +423,14 @@ document.addEventListener("DOMContentLoaded", () => {
   const aboutButton = document.getElementById("button-about");
   const dialog = document.getElementById("dialog-about");
   const closeButton = dialog?.querySelector(".dialog__close");
+  const dialogBody = dialog?.querySelector(".dialog__body");
   const dialogHeader = dialog?.querySelector(".dialog__header");
 
   if (aboutButton && dialog) {
     aboutButton.addEventListener("click", () => {
       rotationController.disable();
       dialog.showModal();
+      dialogBody?.focus();
     });
 
     dialog.addEventListener("close", () => {


### PR DESCRIPTION
When showModal() is called, browsers auto-focus the first focusable
element. By making the dialog body focusable (tabindex="-1") and
explicitly focusing it, we avoid the visible focus ring on the close
button while maintaining keyboard accessibility.